### PR TITLE
chore: bump version to 0.2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "fastapi-githubapp"
-version = "0.2.6"
+version = "0.2.7"
 description = "FastAPI extension for rapid GitHub App development"
 readme = "README.md"
 authors = ["primetheus <865381+primetheus@users.noreply.github.com>"]


### PR DESCRIPTION
## Summary

Bump version in `pyproject.toml` from `0.2.6` to `0.2.7` to match the `v0.2.7` tag.

## Context

The publish workflow triggered on tag `v0.2.7` but `pyproject.toml` still had `version = "0.2.6"`. PyPI rejected the upload because `0.2.6` already exists.

After merging, delete the existing `v0.2.7` tag and re-tag from the updated main:

```bash
git tag -d v0.2.7
git push origin :refs/tags/v0.2.7
git tag v0.2.7
git push origin v0.2.7
```